### PR TITLE
use sqlalchemy's pre-ping to automatically reconnect to database

### DIFF
--- a/wads/__init__.py
+++ b/wads/__init__.py
@@ -8,6 +8,7 @@ def get_app(config_override={}):
     app = Flask(__name__)
     CORS(app)
     app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('PCDS_DSN', 'postgresql://httpd@monsoon.pcic.uvic.ca/crmp')
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {"pool_pre_ping": True}
     app.config.update(config_override)
     add_routes(app)
     return app


### PR DESCRIPTION
We've seen a few 500s on the backend. A easy solution that has helped on other backends is to enable sqlalchemy's built in `pool_pre_ping` feature, which checks to make sure connections are up by sending a trivial `SELECT` before sending actual `SELECT`s used by the backend to test whether the database connection is up, reconnecting behind the scenes if necessary. This is a single line config change.

[Here's a demo](https://beehive.pacificclimate.org/weather-anomaly-viewer/app) running against this backend, but there shouldn't be any visible change, it should just drop database connections less often.

Resolves #14 